### PR TITLE
docs:  clarify content of desired resources in composition functions

### DIFF
--- a/content/master/concepts/composition-functions.md
+++ b/content/master/concepts/composition-functions.md
@@ -348,10 +348,17 @@ The `desired` state of the XR and composed resources is how your Function tells
 Crossplane what it should do. Crossplane 'bootstraps' the initial desired state
 passed to a Function pipeline with:
 
-* A copy of the observed state of the XR.
-* A copy of the observed state of any existing composed resources.
+* A copy of the observed state of the composite resource (XR).
+* A copy of the observed state of any existing composed resources produced
+  from the `resources` array.
 * Any new composed resources or modifications to observed resources produced
   from the `resources` array.
+
+{{< hint "note" >}}
+The initial desired state doesn't include any copies of observed resources
+produced by the function pipeline. When using multiple functions each function
+passes their desired resources output as input to the next pipeline function.
+{{< /hint >}}
 
 When adding a new desired resource to the `desired.resources` array you don't
 need to:


### PR DESCRIPTION
Resolves https://github.com/crossplane/docs/issues/502

Clarifies content of `desired.resources` and when resources produced by function pipeline may be present. It is now less likely that someone thinks resources produced by a function pipeline is also copied from `observed` to `desired` during _bootstrapping_ of initial desired state.

- I think it is good actually use the word _composite_, as it refers to the `composite` field within `desired`
- Clarifies that _existing composed resources_  are produced from the `resources` array (same origin as _new_ and _modified_)
- Explicitly states that initial desired state does not contain resources produced by the function pipeline
- And that the desired resources output of a function is passed as input to the next pipeline function
